### PR TITLE
Render notes without a wrapped <p> tag as textile for backwards compatibility

### DIFF
--- a/lib/redmine_ckeditor/wiki_formatting/formatter.rb
+++ b/lib/redmine_ckeditor/wiki_formatting/formatter.rb
@@ -5,9 +5,17 @@ module RedmineCkeditor::WikiFormatting
     end
 
     def to_html(&block)
-      ActionView::Base.white_list_sanitizer.sanitize @text,
-        :tags => RedmineCkeditor::ALLOWED_TAGS,
-        :attributes => RedmineCkeditor::ALLOWED_ATTRIBUTES
+      # If there are comments in the textile format, then format those as textile still for
+      # backwards compatibility.
+      # This is determined by whether the text is wrapped in a <p> tag.
+      if @text.match(/<p>.*<\/p>/).nil?
+        textile_formatter = Redmine::WikiFormatting::Textile::Formatter.new(@text)
+        textile_formatter.to_html
+      else
+        ActionView::Base.white_list_sanitizer.sanitize @text,
+          :tags => RedmineCkeditor::ALLOWED_TAGS,
+          :attributes => RedmineCkeditor::ALLOWED_ATTRIBUTES
+      end
     end
   end
 end


### PR DESCRIPTION
We use Redmine at work, and I would love to implement the ckeditor, but there are already a lot of notes that are present in the textile format. Rather than have these look weird when the ckeditor is implemented, I would rather have the old notes properly formatted as well as new html formatted notes.

So this pull request does a check when rendering the note to look for any notes not wrapped in a <p> tag and uses the default textile formatter on those. This keeps old notes as they were and also properly renders new notes.
