### PR TITLE
Update redmine_ckeditor.rb

### DIFF
--- a/lib/redmine_ckeditor.rb
+++ b/lib/redmine_ckeditor.rb
@@ -22,7 +22,7 @@ module RedmineCkeditor
       @allowed_attributes ||= %w[
         href src width height alt cite datetime title class name xml:lang abbr dir
         style align valign border cellpadding cellspacing colspan rowspan nowrap
-        start reversed
+        start reversed lang onclick target data-pbcklang data-pbcktabsize
       ]
     end
 


### PR DESCRIPTION
Those attributes (onclick target) are required for the operation of CkEditor with the links: target for a different target page, onclick to open a javascript popup windows. The attributes data-pbcklang data-pbcktabsize are required by the CkEditor plugin pbckcode. 