### PR TITLE
hack fix for redmine_tags conflict

### DIFF
--- a/app/views/settings/_ckeditor.html.erb
+++ b/app/views/settings/_ckeditor.html.erb
@@ -1,4 +1,4 @@
-<%= ckeditor_javascripts %>
+<%= RedmineCkeditor::Helper.instance_method(:ckeditor_javascripts).bind(self).call %>
 <%= stylesheet_link_tag 'editor', :plugin => 'redmine_ckeditor'%>
 <%= stylesheet_link_tag 'selector', :plugin => 'redmine_ckeditor'%>
 <p>


### PR DESCRIPTION
My Ruby is no good but this change does resolve the conflict with the redmine_tags (and redmineup_tags) plugin (issue #293). I do not understand why it is necessary though.