### PR TITLE
Only format the incoming mails Ckeditor is enabled.

### DIFF
--- a/lib/redmine_ckeditor/mail_handler_patch.rb
+++ b/lib/redmine_ckeditor/mail_handler_patch.rb
@@ -3,7 +3,7 @@ module RedmineCkeditor
     include ActionView::Helpers::TextHelper
 
     def cleaned_up_text_body(format = true)
-      if format
+      if RedmineCkeditor.enabled? and format
         simple_format(super())
       else
         super()


### PR DESCRIPTION
Disable incoming mail formating if the text formatter is not Ckeditor, because it can break other text formatters.