### PR TITLE
ckeditor   browse and upload image   error 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rich', git: 'https://github.com/a-ono/rich.git', tag: '1.5.2'
+gem 'rich', git: 'https://github.com/nomadli/rich.git', tag: '1.5.3'
 gem 'kaminari'
 gem 'htmlentities'
 gem 'paperclip', '~> 6.1.0'

--- a/README.rdoc
+++ b/README.rdoc
@@ -17,7 +17,7 @@ See {the official site}[http://ckeditor.com/] for more details.
    # Mac OS X
    brew install imagemagick
    
-* Redmine 5.x (version {1.2.4}[https://github.com/a-ono/redmine_ckeditor/releases/tag/1.2.4])
+* Redmine 5.x (version {1.2.4}[https://github.com/nomadli/redmine_ckeditor/releases/tag/1.2.4])
 
 * Redmine 4.x (version {1.2.3}[https://github.com/a-ono/redmine_ckeditor/releases/tag/1.2.3])
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -16,6 +16,8 @@ See {the official site}[http://ckeditor.com/] for more details.
    apt-get install imagemagick
    # Mac OS X
    brew install imagemagick
+   
+* Redmine 5.x (version {1.2.4}[https://github.com/a-ono/redmine_ckeditor/releases/tag/1.2.4])
 
 * Redmine 4.x (version {1.2.3}[https://github.com/a-ono/redmine_ckeditor/releases/tag/1.2.3])
 

--- a/init.rb
+++ b/init.rb
@@ -1,17 +1,29 @@
 require 'redmine'
-require 'redmine_ckeditor'
 
-ActiveSupport::Reloader.to_prepare do
-  RedmineCkeditor.apply_patch
+plugin_name = :redmine_ckeditor
+plugin_root = File.dirname(__FILE__)
+
+unless defined?(SmileTools)
+    require plugin_root + '/lib/redmine_ckeditor'
+end
+
+if Rails.version > '6.0' && Rails.autoloaders.zeitwerk_enabled?
+  Rails.application.config.after_initialize do
+    RedmineCkeditor.apply_patch
+  end
+else
+  Rails.configuration.to_prepare do
+    RedmineCkeditor.apply_patch
+  end
 end
 
 Redmine::Plugin.register :redmine_ckeditor do
   name 'Redmine CKEditor plugin'
   author 'Akihiro Ono'
   description 'This is a CKEditor plugin for Redmine'
-  version '1.2.3'
-  requires_redmine :version_or_higher => '4.0.0'
-  url 'http://github.com/a-ono/redmine_ckeditor'
+  version '1.2.4'
+  requires_redmine :version_or_higher => '5.0.0'
+  url 'https://github.com/nomadli/redmine_ckeditor'
 
   settings(:partial => 'settings/ckeditor')
 

--- a/lib/generators/redmine_ckeditor/rich_assets/rich_assets_generator.rb
+++ b/lib/generators/redmine_ckeditor/rich_assets/rich_assets_generator.rb
@@ -1,36 +1,40 @@
 require 'rake'
 require 'rails/generators'
 
-module RedmineCkeditor
-  class RichAssetsGenerator < Rails::Generators::Base
-    source_root File.expand_path('../templates', __FILE__)
-    desc "Generate rich asset files for Redmine"
-    def create_assets
-      rake "redmine_ckeditor:assets:copy"
+module Generators
+  module RedmineCkeditor
+    module RichAssets
+      class RichAssetsGenerator < Rails::Generators::Base
+        source_root File.expand_path('../templates', __FILE__)
+        desc "Generate rich asset files for Redmine"
+        def create_assets
+          rake "redmine_ckeditor:assets:copy"
 
-      gsub_file RedmineCkeditor.root.join("assets/ckeditor-contrib/plugins/richfile/plugin.js"),
-        "/assets/rich/", "../images/"
+          gsub_file RedmineCkeditor.root.join("assets/ckeditor-contrib/plugins/richfile/plugin.js"),
+            "/assets/rich/", "../images/"
 
-      application_js = RedmineCkeditor.root.join("assets/javascripts/application.js")
-      browser_js = RedmineCkeditor.root.join("assets/javascripts/browser.js")
+          application_js = RedmineCkeditor.root.join("assets/javascripts/application.js")
+          browser_js = RedmineCkeditor.root.join("assets/javascripts/browser.js")
 
-      gsub_file browser_js, "opt=opt.split(',');", "opt=opt ? opt.split(',') : [];"
+          gsub_file browser_js, "opt=opt.split(',');", "opt=opt ? opt.split(',') : [];"
 
-      gsub_file application_js, /var CKEDITOR_BASEPATH.+$/, ""
+          gsub_file application_js, /var CKEDITOR_BASEPATH.+$/, ""
 
-      gsub_file application_js, /CKEDITOR.plugins.addExternal.+$/, ""
+          gsub_file application_js, /CKEDITOR.plugins.addExternal.+$/, ""
 
-      gsub_file browser_js, '"/rich/files/"+', ""
+          gsub_file browser_js, '"/rich/files/"+', ""
 
-      inject_into_file browser_js,
-        "\t\turl = $(item).data('relative-url-root') + url;\n",
-        :after => "data('uris')[this._options.currentStyle];\n"
+          inject_into_file browser_js,
+            "\t\turl = $(item).data('relative-url-root') + url;\n",
+            :after => "data('uris')[this._options.currentStyle];\n"
 
-      gsub_file RedmineCkeditor.root.join("assets/stylesheets/application.css"),
-        'image-url("rich/', 'url("../images/'
+          gsub_file RedmineCkeditor.root.join("assets/stylesheets/application.css"),
+            'image-url("rich/', 'url("../images/'
 
-      append_to_file RedmineCkeditor.root.join("assets/stylesheets/editor.css"),
-        "\nhtml, body {\n  height: 100%;\n}\n"
+          append_to_file RedmineCkeditor.root.join("assets/stylesheets/editor.css"),
+            "\nhtml, body {\n  height: 100%;\n}\n"
+        end
+      end
     end
   end
 end

--- a/lib/redmine_ckeditor.rb
+++ b/lib/redmine_ckeditor.rb
@@ -138,12 +138,15 @@ module RedmineCkeditor
   end
 end
 
-require 'redmine_ckeditor/helper'
-require 'redmine_ckeditor/application_helper_patch'
-require 'redmine_ckeditor/queries_helper_patch'
-require 'redmine_ckeditor/rich_files_helper_patch'
-require 'redmine_ckeditor/journals_controller_patch'
-require 'redmine_ckeditor/messages_controller_patch'
-require 'redmine_ckeditor/mail_handler_patch'
-require 'redmine_ckeditor/pdf_patch'
-require 'redmine_ckeditor/tempfile_patch'
+plugin_name = :redmine_ckeditor
+plugin_root = File.dirname(__FILE__)
+
+require plugin_root + '/redmine_ckeditor/helper'
+require plugin_root + '/redmine_ckeditor/application_helper_patch'
+require plugin_root + '/redmine_ckeditor/queries_helper_patch'
+require plugin_root + '/redmine_ckeditor/rich_files_helper_patch'
+require plugin_root + '/redmine_ckeditor/journals_controller_patch'
+require plugin_root + '/redmine_ckeditor/messages_controller_patch'
+require plugin_root + '/redmine_ckeditor/mail_handler_patch'
+require plugin_root + '/redmine_ckeditor/pdf_patch'
+require plugin_root + '/redmine_ckeditor/tempfile_patch'

--- a/lib/redmine_ckeditor/pdf_patch.rb
+++ b/lib/redmine_ckeditor/pdf_patch.rb
@@ -1,5 +1,5 @@
 module RedmineCkeditor
-  module PDFPatch
+  module PdfPatch
     def formatted_text(text)
       html = super
       html = HTMLEntities.new.decode(html) if RedmineCkeditor.enabled?
@@ -48,4 +48,4 @@ module RedmineCkeditor
   end
 end
 
-Redmine::Export::PDF::ITCPDF.prepend RedmineCkeditor::PDFPatch
+Redmine::Export::PDF::ITCPDF.prepend RedmineCkeditor::PdfPatch

--- a/lib/redmine_ckeditor/wiki_formatting/formatter.rb
+++ b/lib/redmine_ckeditor/wiki_formatting/formatter.rb
@@ -1,6 +1,7 @@
 module RedmineCkeditor::WikiFormatting
   class Formatter
     include Redmine::WikiFormatting::LinksHelper
+    include ActionView::Helpers::SanitizeHelper
 
     def initialize(text)
       @text = text
@@ -24,7 +25,7 @@ module RedmineCkeditor::WikiFormatting
       }
 
       auto_link!(text)
-      text = ActionView::Base.white_list_sanitizer.sanitize(text,
+      text = ActionController::Base.helpers.sanitize(text,
         :tags => RedmineCkeditor.allowed_tags,
         :attributes => RedmineCkeditor.allowed_attributes
       )


### PR DESCRIPTION
Hello ..

i upgrade redmine 5.0 and  installed  plugin  redmin_ckeditor 1.2.4  

it works  well ,   but  click and error   'browse and upload images  icon'   when i  tried upload images ..

please  check this ... 

I, [2022-10-30T07:28:23.424614 #195725]  INFO -- : [0e8a5a8a-2a54-40c6-a0b4-5372ac66701f] Started GET "/rich/files/?CKEditor=project_description&CKEditorFuncNum=2&default_style=original&allowed_styles=thumb%2Crich_thumb%2Coriginal&insert_many=false&type=image&scoped=true&scope_type=Project&scope_id=277&viewMode=grid" for 192.168.219.1 at 2022-10-30 07:28:23 +0000
I, [2022-10-30T07:28:23.428100 #195725]  INFO -- : [0e8a5a8a-2a54-40c6-a0b4-5372ac66701f] Processing by Rich::FilesController#index as HTML
I, [2022-10-30T07:28:23.428350 #195725]  INFO -- : [0e8a5a8a-2a54-40c6-a0b4-5372ac66701f]   Parameters: {"CKEditor"=>"project_description", "CKEditorFuncNum"=>"2", "default_style"=>"original", "allowed_styles"=>"thumb,rich_thumb,original", "insert_many"=>"false", "type"=>"image", "scoped"=>"true", "scope_type"=>"Project", "scope_id"=>"277", "viewMode"=>"grid"}
I, [2022-10-30T07:28:23.477959 #195725]  INFO -- : [0e8a5a8a-2a54-40c6-a0b4-5372ac66701f]   Current user: choiss (id=3)
I, [2022-10-30T07:28:23.495447 #195725]  INFO -- : [0e8a5a8a-2a54-40c6-a0b4-5372ac66701f]   Rendered /opt/bitnami/ruby/lib/ruby/gems/3.0.0/bundler/gems/rich-331110a2a539/app/views/rich/files/index.html.erb within layouts/rich/application (Duration: 12.6ms | Allocations: 2037)
I, [2022-10-30T07:28:23.495734 #195725]  INFO -- : [0e8a5a8a-2a54-40c6-a0b4-5372ac66701f]   Rendered layout plugins/redmine_ckeditor/app/views/layouts/rich/application.html.erb (Duration: 13.0ms | Allocations: 2063)
I, [2022-10-30T07:28:23.496290 #195725]  INFO -- : [0e8a5a8a-2a54-40c6-a0b4-5372ac66701f] Completed 500 Internal Server Error in 68ms (ActiveRecord: 40.4ms | Allocations: 4071)
F, [2022-10-30T07:28:23.499018 #195725] FATAL -- : [0e8a5a8a-2a54-40c6-a0b4-5372ac66701f]   
[0e8a5a8a-2a54-40c6-a0b4-5372ac66701f] ActionView::Template::Error (undefined method `escape' for URI:Module):
[0e8a5a8a-2a54-40c6-a0b4-5372ac66701f]     1: <li class="clickable">
[0e8a5a8a-2a54-40c6-a0b4-5372ac66701f]     2:   <img  id="file<%= file.id %>"
[0e8a5a8a-2a54-40c6-a0b4-5372ac66701f]     3:         src="<%= thumb_for_file(file) %>" 
[0e8a5a8a-2a54-40c6-a0b4-5372ac66701f]     4:         data-uris="<%= file.uri_cache %>"
[0e8a5a8a-2a54-40c6-a0b4-5372ac66701f]     5:         data-relative-url-root="<%= Redmine::Utils.relative_url_root %>"
[0e8a5a8a-2a54-40c6-a0b4-5372ac66701f]     6:         data-rich-asset-id="<%= file.id %>"
[0e8a5a8a-2a54-40c6-a0b4-5372ac66701f]   
[0e8a5a8a-2a54-40c6-a0b4-5372ac66701f] plugins/redmine_ckeditor/lib/redmine_ckeditor/rich_files_helper_patch.rb:5:in `thumb_for_file'
[0e8a5a8a-2a54-40c6-a0b4-5372ac66701f] plugins/redmine_ckeditor/app/views/rich/files/_file.html.erb:3
[0e8a5a8a-2a54-40c6-a0b4-5372ac66701f] lib/redmine/sudo_mode.rb:61:in `sudo_mode'
